### PR TITLE
Allow setting release notes

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,12 +13,27 @@ def main():
     parser.add_argument('aab_file', type=str, help='Path of the Android App Bundle file')
     parser.add_argument('track', choices=['production', 'alpha', 'beta', 'internal'], default='internal',
                         help='Track to upload the apk to')
+    parser.add_argument(
+        '--release-notes', '-n',
+        type=str,
+        nargs=2,
+        action='append',
+        default=[],
+        help='''
+            User-facing notes for the release in the specified language,
+            e.g. "--release-notes en-US 'Bug fixes and performance improvements.'".
+            Can be specified multiple times for multiple languages.
+            For language codes see https://support.google.com/googleplay/android-developer/table/4419860
+        ''',
+        metavar=('LANGUAGE', 'TEXT')
+    )
     args = parser.parse_args()
 
     service_account_file = args.service_account_file
     package_name = args.package_name
     app_bundle_file = args.aab_file
     track = args.track
+    release_notes = list(map(lambda pair: {"language": pair[0], "text": pair[1]}, args.release_notes))
 
     # Load credentials
     credentials = ServiceAccountCredentials.from_json_keyfile_name(
@@ -49,7 +64,8 @@ def main():
             body={
                 'releases': [{
                     'versionCodes': [aab_response['versionCode']],
-                    'status': 'completed'
+                    'status': 'completed',
+                    'releaseNotes': release_notes,
                 }]
             }).execute()
         print('Track {} is set for version code(s) {}'.format(track, track_response['releases']))

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def main():
     package_name = args.package_name
     app_bundle_file = args.aab_file
     track = args.track
-    release_notes = list(map(lambda note: {"language": note[0], "text": note[1]}, args.release_notes))
+    release_notes = [{"language": note[0], "text": note[1]} for note in args.release_notes]
 
     # Load credentials
     credentials = ServiceAccountCredentials.from_json_keyfile_name(

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ def main():
     package_name = args.package_name
     app_bundle_file = args.aab_file
     track = args.track
-    release_notes = list(map(lambda pair: {"language": pair[0], "text": pair[1]}, args.release_notes))
+    release_notes = list(map(lambda note: {"language": note[0], "text": note[1]}, args.release_notes))
 
     # Load credentials
     credentials = ServiceAccountCredentials.from_json_keyfile_name(


### PR DESCRIPTION
Thanks for this great script! It's made my life a lot easier. I wanted to be able to set release notes from it, so I built this argument.

```sh
python main.py key.json package.name release.aab --release-notes en-US "Performance improvements"
```

It also supports multiple languages:
```sh
python main.py key.json package.name release.aab --release-notes en-US "Performance improvements" --release-notes zh-CN "性能提升"
```

If not provided, everything will work as it does currently.

My use case for building this is to automatically generate release notes from recent Git commits :) Thanks again! Let me know if there's anything you want me to change.